### PR TITLE
Move to new standalone installerapi and implement some basic functions and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 script: "npm run-script test-travis"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ const UbpApi = require("./src/module.js");
 const devices = new UbpApi.Devices();
 const installer = new UbpApi.Installer();
 
-installer.getInstallInstructs("FP2").then((device) => console.log("Device: " + device.name));
 devices.getNotWorking("FP2").then((notWorking) => console.log("Not working: " + notWorking));
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ubports-api-node-module",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ubports-api-node-module",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "This is a nodejs module to talk to ubports apis and services, built using modern javascript.",
   "main": "src/module.js",
   "scripts": {

--- a/src/installer.js
+++ b/src/installer.js
@@ -18,7 +18,7 @@
 
 const HttpApi = require("./http.js");
 
-const DEFAULT_HOST = "https://devices.ubports.com/";
+const DEFAULT_HOST = "https://raw.githubusercontent.com/ubports/installer-configs/master/";
 
 class Installer extends HttpApi {
   constructor(options) {
@@ -30,15 +30,33 @@ class Installer extends HttpApi {
   }
 
   getDevices() {
-    return this._get("api/installer/devices");
+    return this._get("index.json");
   }
 
-  getDevice(device) {
-    return this._get("api/installer/devices/"+device);
+  getDeviceSelects() {
+    var _this = this;
+    return new Promise(function(resolve, reject) {
+      _this.getDevices().then((devices) => {
+        var devicesAppend = [];
+        Object.entries(devices).forEach((device) => {
+          devicesAppend.push("<option name=\"" + device[0] + "\">" + device[1] + "</option>");
+        });
+        resolve(devicesAppend.join(''));
+      }).catch(reject);
+    });
   }
 
-  getInstallInstructs(device) {
-    return this._get("api/installer/"+device);
+  getAliases() {
+    return this._get("aliases.json");
+  }
+
+  resolveAlias(codename) {
+    var _this = this;
+    return new Promise(function(resolve, reject) {
+      _this.getAliases().then((aliases) => {
+        resolve(aliases[codename] || codename);
+      }).catch(reject);
+    });
   }
 }
 

--- a/tests/unit-tests/test_installer.js
+++ b/tests/unit-tests/test_installer.js
@@ -27,15 +27,11 @@ chai.use(sinonChai);
 
 const Installer = require('../../src/module.js').Installer;
 
-const devicesJson = require("../test-data/devices.json")
-const deviceBaconJson = require("../test-data/device-bacon.json")
-const deviceFP2Json = require("../test-data/device-FP2.json")
-
 describe('Installer module', function() {
   describe("constructor()", function() {
     it("should create default installer-api-client", function() {
       const api = new Installer();
-      expect(api.host).to.eql("https://devices.ubports.com/");
+      expect(api.host).to.eql("https://raw.githubusercontent.com/ubports/installer-configs/master/");
     });
 
     it("should create custom installer-api-client", function() {
@@ -76,14 +72,14 @@ describe('Installer module', function() {
   describe("getDevices()", function() {
     it("should return devices", function() {
       const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
-        cb(false, {statusCode: 200}, devicesJson);
+        cb(false, {statusCode: 200}, {codename_1: "Name 1", codename_2: "Name 2"});
       });
 
       const api = new Installer();
       return api.getDevices().then((result) => {
-        expect(result).to.eql(devicesJson);
+        expect(result).to.eql({codename_1: "Name 1", codename_2: "Name 2"});
         expect(requestStub).to.have.been.calledWith({
-          url: "https://devices.ubports.com/api/installer/devices",
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/index.json",
           json: true
         });
       });
@@ -91,31 +87,31 @@ describe('Installer module', function() {
 
     it("should return error", function() {
       const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
-        cb(true, {statusCode: 500}, devicesJson);
+        cb(true, {statusCode: 500}, null);
       });
 
       const api = new Installer();
       return api.getDevices().then(() => {}).catch((err) => {
         expect(err).to.eql(true);
         expect(requestStub).to.have.been.calledWith({
-          url: "https://devices.ubports.com/api/installer/devices",
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/index.json",
           json: true
         });
       });
     });
   });
 
-  describe("getDevice()", function() {
-    it("should return devices", function() {
+  describe("getDeviceSelects()", function() {
+    it("should return device selects", function() {
       const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
-        cb(false, {statusCode: 200}, deviceBaconJson);
+        cb(false, {statusCode: 200}, {codename_1: "Name 1", codename_2: "Name 2"});
       });
 
       const api = new Installer();
-      return api.getDevice("bacon").then((result) => {
-        expect(result).to.eql(deviceBaconJson);
+      return api.getDeviceSelects().then((result) => {
+        expect(result).to.eql('<option name="codename_1">Name 1</option><option name="codename_2">Name 2</option>');
         expect(requestStub).to.have.been.calledWith({
-          url: "https://devices.ubports.com/api/installer/devices/bacon",
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/index.json",
           json: true
         });
       });
@@ -123,31 +119,31 @@ describe('Installer module', function() {
 
     it("should return error", function() {
       const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
-        cb(true, {statusCode: 500}, deviceBaconJson);
+        cb(true, {statusCode: 500}, null);
       });
 
       const api = new Installer();
-      return api.getDevice("bacon").then(() => {}).catch((err) => {
+      return api.getDeviceSelects().then(() => {}).catch((err) => {
         expect(err).to.eql(true);
         expect(requestStub).to.have.been.calledWith({
-          url: "https://devices.ubports.com/api/installer/devices/bacon",
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/index.json",
           json: true
         });
       });
     });
   });
 
-  describe("getInstallInstructs()", function() {
-    it("should return devices", function() {
+  describe("getAliases()", function() {
+    it("should return aliases", function() {
       const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
-        cb(false, {statusCode: 200}, deviceBaconJson);
+        cb(false, {statusCode: 200}, {alias_1: "codename_1", alias_2: "codename_2"});
       });
 
       const api = new Installer();
-      return api.getInstallInstructs("bacon").then((result) => {
-        expect(result).to.eql(deviceBaconJson);
+      return api.getAliases().then((result) => {
+        expect(result).to.eql({alias_1: "codename_1", alias_2: "codename_2"});
         expect(requestStub).to.have.been.calledWith({
-          url: "https://devices.ubports.com/api/installer/bacon",
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/aliases.json",
           json: true
         });
       });
@@ -155,17 +151,50 @@ describe('Installer module', function() {
 
     it("should return error", function() {
       const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
-        cb(true, {statusCode: 500}, deviceBaconJson);
+        cb(true, {statusCode: 500}, null);
       });
 
       const api = new Installer();
-      return api.getInstallInstructs("bacon").then(() => {}).catch((err) => {
+      return api.getAliases().then(() => {}).catch((err) => {
         expect(err).to.eql(true);
         expect(requestStub).to.have.been.calledWith({
-          url: "https://devices.ubports.com/api/installer/bacon",
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/aliases.json",
           json: true
         });
       });
     });
   });
+
+  describe("resolveAlias()", function() {
+    it("should resolve alias", function() {
+      const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
+        cb(false, {statusCode: 200}, {alias_1: "codename_1", alias_2: "codename_2"});
+      });
+
+      const api = new Installer();
+      return api.resolveAlias("alias_1").then((result) => {
+        expect(result).to.eql("codename_1");
+        expect(requestStub).to.have.been.calledWith({
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/aliases.json",
+          json: true
+        });
+      });
+    });
+
+    it("should not resolve valid codename", function() {
+      const requestStub = this.sandbox.stub(request, 'get').callsFake(function(url, cb) {
+        cb(false, {statusCode: 200}, {alias_1: "codename_1", alias_2: "codename_2"});
+      });
+
+      const api = new Installer();
+      return api.resolveAlias("codename_1").then((result) => {
+        expect(result).to.eql("codename_1");
+        expect(requestStub).to.have.been.calledWith({
+          url: "https://raw.githubusercontent.com/ubports/installer-configs/master/aliases.json",
+          json: true
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
This moves to the in-dev [standalone installer api](https://github.com/ubports/installer-configs). Not much there yet, but we can already get this in there. Will add the rest step by step as we are nailing down all the details.

This is a requirement for the ongoing work on the 0.4.x-beta branch of the installer.